### PR TITLE
Fix video caching, moving to a synchronous upload to S3

### DIFF
--- a/src/kolibri2zim/constants.py
+++ b/src/kolibri2zim/constants.py
@@ -50,21 +50,11 @@ def is_running_inside_container():
 
 
 class Global:
-    debug = False
     inside_container = is_running_inside_container()
+    logger = lib_getLogger(NAME, logging.INFO)
     nb_available_cpus: int
 
 
 Global.nb_available_cpus = (
     1 if Global.inside_container else multiprocessing.cpu_count() - 1 or 1
 )
-
-
-def set_debug(debug):
-    """toggle constants global DEBUG flag (used by getLogger)"""
-    Global.debug = bool(debug)
-
-
-def get_logger():
-    """configured logger respecting DEBUG flag"""
-    return lib_getLogger(NAME, level=logging.DEBUG if Global.debug else logging.INFO)

--- a/src/kolibri2zim/entrypoint.py
+++ b/src/kolibri2zim/entrypoint.py
@@ -4,7 +4,7 @@
 import argparse
 import sys
 
-from kolibri2zim.constants import NAME, SCRAPER, Global, get_logger, set_debug
+from kolibri2zim.constants import NAME, SCRAPER, Global
 from kolibri2zim.scraper import Kolibri2Zim
 
 
@@ -206,8 +206,10 @@ def parse_args(raw_args):
 
 def main():
     args = parse_args(sys.argv[1:])
-    set_debug(args.debug)
-    logger = get_logger()
+    if args.debug:
+        for handler in Global.logger.handlers:
+            handler.setLevel("DEBUG")
+    logger = Global.logger
 
     try:
         scraper = Kolibri2Zim(**dict(args._get_kwargs()))

--- a/src/kolibri2zim/processing.py
+++ b/src/kolibri2zim/processing.py
@@ -3,9 +3,9 @@
 
 from zimscraperlib.video.encoding import reencode
 
-from kolibri2zim.constants import get_logger
+from kolibri2zim.constants import Global
 
-logger = get_logger()
+logger = Global.logger
 
 
 def post_process_video(video_dir, video_id, preset, video_format, low_quality):

--- a/src/kolibri2zim/scraper.py
+++ b/src/kolibri2zim/scraper.py
@@ -32,7 +32,7 @@ from zimscraperlib.video.presets import VideoMp4Low, VideoWebmHigh, VideoWebmLow
 from zimscraperlib.zim.creator import Creator
 from zimscraperlib.zim.items import StaticItem
 
-from kolibri2zim.constants import JS_DEPS, ROOT_DIR, STUDIO_URL, Global, get_logger
+from kolibri2zim.constants import JS_DEPS, ROOT_DIR, STUDIO_URL, Global
 from kolibri2zim.database import KolibriDB
 from kolibri2zim.debug import (
     ON_DISK_THRESHOLD,
@@ -41,7 +41,7 @@ from kolibri2zim.debug import (
     safer_reencode,
 )
 
-logger = get_logger()
+logger = Global.logger
 options = [
     "debug",
     "name",


### PR DESCRIPTION
## Rationale

Fix #82 

## Changes
- S3 upload is now synchronous with video encoding:
  - way simpler than the callback (which wasn't working anyway)
  - we expect video encoding to consume way more time than upload
  - we are already in parallel processing of videos to convert, so we do not mind much if the whole process takes long (we can just start more video processing threads if needed)
- removed the now useless `pending_upload` dictionary
- remove videos_futures dictionary by a simple list of futures
- cleanup the videos_futures list once future has completed
- add the callback to the video future asap (just in case it finishes early)