### PR TITLE
Enhance situation around videos encoding and caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix caching of re-encoded video files (#82)
+- Do not start multiple video processing threads by default (`--processes` default value) (partial fix of #83)
+- Fix logging issue in DEBUG mode
+
 ## [1.1.1] - 2024-01-16
 
 ### Added

--- a/src/kolibri2zim/constants.py
+++ b/src/kolibri2zim/constants.py
@@ -34,5 +34,4 @@ JS_DEPS: list[str] = [
 ]
 
 
-class Global:
-    logger = lib_getLogger(NAME, logging.INFO)
+logger = lib_getLogger(NAME, logging.INFO)

--- a/src/kolibri2zim/constants.py
+++ b/src/kolibri2zim/constants.py
@@ -50,21 +50,11 @@ def is_running_inside_container():
 
 
 class Global:
-    debug = False
     inside_container = is_running_inside_container()
+    logger = lib_getLogger(NAME, logging.INFO)
     nb_available_cpus: int
 
 
 Global.nb_available_cpus = (
     1 if Global.inside_container else multiprocessing.cpu_count() - 1 or 1
 )
-
-
-def set_debug(debug):
-    """toggle constants global DEBUG flag (used by getLogger)"""
-    Global.debug = bool(debug)
-
-
-def get_logger():
-    """configured logger respecting DEBUG flag"""
-    return lib_getLogger(NAME, level=logging.DEBUG if Global.debug else logging.INFO)

--- a/src/kolibri2zim/constants.py
+++ b/src/kolibri2zim/constants.py
@@ -2,7 +2,6 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 import logging
-import multiprocessing
 import os
 import pathlib
 
@@ -35,26 +34,5 @@ JS_DEPS: list[str] = [
 ]
 
 
-def is_running_inside_container():
-    fpath = pathlib.Path("/proc/self/cgroup")
-    if not fpath.exists():
-        return False
-    try:
-        with open(fpath) as fh:
-            for line in fh.readlines():
-                if line.strip().rsplit(":", 1)[-1] != "/":
-                    return True
-    finally:
-        pass
-    return False
-
-
 class Global:
-    inside_container = is_running_inside_container()
     logger = lib_getLogger(NAME, logging.INFO)
-    nb_available_cpus: int
-
-
-Global.nb_available_cpus = (
-    1 if Global.inside_container else multiprocessing.cpu_count() - 1 or 1
-)

--- a/src/kolibri2zim/entrypoint.py
+++ b/src/kolibri2zim/entrypoint.py
@@ -4,7 +4,7 @@
 import argparse
 import sys
 
-from kolibri2zim.constants import NAME, SCRAPER, Global, get_logger, set_debug
+from kolibri2zim.constants import NAME, SCRAPER, Global
 from kolibri2zim.scraper import Kolibri2Zim
 
 
@@ -206,8 +206,10 @@ def parse_args(raw_args):
 
 def main():
     args = parse_args(sys.argv[1:])
-    set_debug(args.debug)
-    logger = get_logger()
+    if args.debug:
+        for handler in Global.logger.handlers:
+            handler.setLevel("DEBUG")
+    logger = Global.logger
 
     try:
         scraper = Kolibri2Zim(**dict(args._get_kwargs()))

--- a/src/kolibri2zim/entrypoint.py
+++ b/src/kolibri2zim/entrypoint.py
@@ -160,11 +160,10 @@ def parse_args(raw_args):
 
     parser.add_argument(
         "--processes",
-        help="Number of processes to dedicate to media optimizations. "
-        "Defaults to number of available CPU threads visible minus 1 except when run "
-        "inside a container (Docker) where we default to 1 as the detected CPUs are "
-        f"the ones of the host. Default: {Global.nb_available_cpus}",
-        default=Global.nb_available_cpus,
+        help="Number of processes to use to handle video compression. "
+        "Increase when many CPUs are available and video compression is configured to "
+        "use only one CPU. Default: 1",
+        default=1,
         type=int,
     )
 

--- a/src/kolibri2zim/entrypoint.py
+++ b/src/kolibri2zim/entrypoint.py
@@ -4,7 +4,7 @@
 import argparse
 import sys
 
-from kolibri2zim.constants import NAME, SCRAPER, Global
+from kolibri2zim.constants import NAME, SCRAPER, logger
 from kolibri2zim.scraper import Kolibri2Zim
 
 
@@ -206,9 +206,8 @@ def parse_args(raw_args):
 def main():
     args = parse_args(sys.argv[1:])
     if args.debug:
-        for handler in Global.logger.handlers:
+        for handler in logger.handlers:
             handler.setLevel("DEBUG")
-    logger = Global.logger
 
     try:
         scraper = Kolibri2Zim(**dict(args._get_kwargs()))

--- a/src/kolibri2zim/processing.py
+++ b/src/kolibri2zim/processing.py
@@ -3,9 +3,9 @@
 
 from zimscraperlib.video.encoding import reencode
 
-from kolibri2zim.constants import get_logger
+from kolibri2zim.constants import Global
 
-logger = get_logger()
+logger = Global.logger
 
 
 def post_process_video(video_dir, video_id, preset, video_format, low_quality):

--- a/src/kolibri2zim/processing.py
+++ b/src/kolibri2zim/processing.py
@@ -3,9 +3,7 @@
 
 from zimscraperlib.video.encoding import reencode
 
-from kolibri2zim.constants import Global
-
-logger = Global.logger
+from kolibri2zim.constants import logger
 
 
 def post_process_video(video_dir, video_id, preset, video_format, low_quality):

--- a/src/kolibri2zim/scraper.py
+++ b/src/kolibri2zim/scraper.py
@@ -34,7 +34,7 @@ from zimscraperlib.video.presets import VideoMp4Low, VideoWebmHigh, VideoWebmLow
 from zimscraperlib.zim.creator import Creator
 from zimscraperlib.zim.items import StaticItem
 
-from kolibri2zim.constants import JS_DEPS, ROOT_DIR, STUDIO_URL, Global
+from kolibri2zim.constants import JS_DEPS, ROOT_DIR, STUDIO_URL, logger
 from kolibri2zim.database import KolibriDB
 from kolibri2zim.debug import (
     ON_DISK_THRESHOLD,
@@ -43,7 +43,6 @@ from kolibri2zim.debug import (
     safer_reencode,
 )
 
-logger = Global.logger
 options = [
     "debug",
     "name",
@@ -137,7 +136,7 @@ class Kolibri2Zim:
 
         # performances options
         self.nb_threads = int(go("threads") or 1)
-        self.nb_processes = int(go("processes") or Global.nb_available_cpus)
+        self.nb_processes = int(go("processes") or 1)
         self.s3_url_with_credentials = go("s3_url_with_credentials")
         self.s3_storage = None
         self.dedup_html_files = go("dedup_html_files")

--- a/src/kolibri2zim/scraper.py
+++ b/src/kolibri2zim/scraper.py
@@ -32,7 +32,7 @@ from zimscraperlib.video.presets import VideoMp4Low, VideoWebmHigh, VideoWebmLow
 from zimscraperlib.zim.creator import Creator
 from zimscraperlib.zim.items import StaticItem
 
-from kolibri2zim.constants import JS_DEPS, ROOT_DIR, STUDIO_URL, Global, get_logger
+from kolibri2zim.constants import JS_DEPS, ROOT_DIR, STUDIO_URL, Global
 from kolibri2zim.database import KolibriDB
 from kolibri2zim.debug import (
     ON_DISK_THRESHOLD,
@@ -41,7 +41,7 @@ from kolibri2zim.debug import (
     safer_reencode,
 )
 
-logger = get_logger()
+logger = Global.logger
 options = [
     "debug",
     "name",


### PR DESCRIPTION
## Rationale

Fix #82 

#83 is not fully fixed but the situation is way better (we start only one ffmpeg process per scraper run), the rest will be done by https://github.com/openzim/python-scraperlib/issues/123

## Changes
- fix code to really upload the encoded video when cache is configured and really delete 
- fix logging issue (DEBUG level was never displayed) and simplify code
- simplify futures management and clean the list of futures as they complete (only once callback is complete)
- change default value for `--processes` (code detecting the Docker usage was not working anymore and is mostly useless since ffmpeg is already pushing a lot of pressure on the CPU + we usually run inside Docker and do not want multiple ffmpeg instance at the same time, even if they use only one CPU thread)

## Tests

This has been tested with:
```
kolibri2zim --name "test" --output output --tmp-dir tmp --channel-id 878ec2e6f88c5c268b1be6f202833cd4 --node-ids '455c985cf13c59018d9ec1b27b25fdf3,c938b19c971d5c539d4367c07d4ceb8b,759b3f9a20eb5b5d96032faa948f3729,63a274c6174f50999f7011b5e8984e2b,0b64184b660a51faa2acc1977e937d2d,878ec2e6f88c5c268b1be6f202833cd4' --debug --low-quality --use-webm --optimization-cache $OPTIM_CACHE
```

First call re-encodes and uploads the video, second call uses S3 file.