### PR TITLE
Partly solves Issue #72

### DIFF
--- a/zimui/src/components/TopicHome.vue
+++ b/zimui/src/components/TopicHome.vue
@@ -71,6 +71,14 @@ const parentSlug = (): string | null => {
   }
   return topic.value.parents[topic.value.parents.length - 1].slug
 }
+
+/** Navigate to the previous page */
+const goToPreviousPage = () => {
+  // click browser back button 
+  if (window.history.length > 1) {
+    window.history.back()
+  }
+}
 </script>
 
 <template>
@@ -123,18 +131,17 @@ const parentSlug = (): string | null => {
               'col-sm-12': !topic.thumbnail,
             }"
           >
-            <router-link :to="`./${parentSlug()}`">
-              <button
-                v-if="hasParents()"
-                type="button"
-                class="btn back-button rounded-circle btn-secondary light"
-              >
-                <FontAwesomeIcon
-                  aria-label="Arrow Left icon"
-                  icon="fa-solid fa-arrow-left"
-                />
-              </button>
-            </router-link>
+            <button
+              @click="goToPreviousPage"
+              v-if="hasParents()"
+              type="button"
+              class="btn back-button rounded-circle btn-secondary light"
+            >
+              <FontAwesomeIcon
+                aria-label="Arrow Left icon"
+                icon="fa-solid fa-arrow-left"
+              />
+            </button>
             <h1 class="d-md-none h3">{{ topic.title }}</h1>
             <h1 class="d-md-block d-none">{{ topic.title }}</h1>
             <div class="lead mb-2">

--- a/zimui/src/pages/HomePage.vue
+++ b/zimui/src/pages/HomePage.vue
@@ -12,6 +12,9 @@ const topic: Ref<string> = ref(params.value.topic as string)
 // update topic when route params are changed
 watch(params, () => {
   topic.value = params.value.topic as string
+  if (topic.value === undefined && main.channelData != null) {
+    topic.value = main.channelData.rootSlug
+  }
 })
 
 // fetch channel data and set default topic if needed


### PR DESCRIPTION
Partly solves #72
**Issue 1 - Clicking browser back button after going from root page to some topic page is not taking me back to root page**

https://github.com/openzim/kolibri/assets/96630446/850b58ec-80bf-4b00-9712-8a08a07c8115

**Solution** - In HomePage , watch params. If topic changes and is undefined then assign it the rootSlug value

**Issue 2 - Clicking App Back Icon is pushing a new page with parent slug**

https://github.com/openzim/kolibri/assets/96630446/f312cf22-bcc3-4ada-849e-a409c1447d0d

**Solution** - It should be consistent with browser back button [endless ui](https://key.endlessos.org/en/explore/#/topics/c9d7f950ab6b5a1199e3d6c10d7f0103rl)

After fixing the issue

https://github.com/openzim/kolibri/assets/96630446/ce533792-0903-4fac-80d8-49e5223ffa61



