### PR TITLE
Add Tags toolbar feature

### DIFF
--- a/zimui/package.json
+++ b/zimui/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@popperjs/core": "^2.11.8",
+    "@types/bootstrap": "^5.2.10",
     "@types/glob": "^8.1.0",
     "@types/marked": "^4.0.8",
     "@typescript-eslint/eslint-plugin": "^5.58.0",

--- a/zimui/src/components/TagButton.vue
+++ b/zimui/src/components/TagButton.vue
@@ -8,13 +8,25 @@ defineProps({
 </script>
 
 <template>
-  <router-link class="text-decoration-none text-reset" :to="`./${data.slug}`">
+  <div v-if="data.kind == 'topic'">
+    <router-link class="text-decoration-none text-reset" :to="`./${data.slug}`">
+      <div role="group" class="mx-1 my-1 btn-group btn-group-sm">
+        <a class="btn btn-primary btn-sm rounded-pill tagbutton">
+          {{ data.title }}
+        </a>
+      </div>
+    </router-link>
+  </div>
+  <div v-else>
     <div role="group" class="mx-1 my-1 btn-group btn-group-sm">
-      <a class="btn btn-primary btn-sm rounded-pill tagbutton" style="">
+      <a
+        class="btn btn-primary btn-sm rounded-pill tagbutton"
+        :href="`./files/${data.slug}`"
+      >
         {{ data.title }}
       </a>
     </div>
-  </router-link>
+  </div>
 </template>
 
 <style scoped>

--- a/zimui/src/components/TagButton.vue
+++ b/zimui/src/components/TagButton.vue
@@ -1,31 +1,45 @@
 <script setup lang="ts">
+import { onMounted } from 'vue'
+import { Tooltip } from 'bootstrap'
 defineProps({
   data: {
     type: Object,
     required: true,
   },
 })
+
+onMounted(() => {
+  //initialize tooltip
+  const tooltipTriggerList = document.querySelectorAll(
+    '[data-toggle="tooltip"]',
+  )
+  tooltipTriggerList.forEach(function (tooltipTriggerEl) {
+    const tooltip = new Tooltip(tooltipTriggerEl, {
+      trigger: 'hover',
+    })
+    tooltipTriggerEl.addEventListener('click', () => {
+      tooltip.dispose()
+    })
+  })
+})
 </script>
 
 <template>
-  <div v-if="data.kind == 'topic'">
+  <div>
     <router-link class="text-decoration-none text-reset" :to="`./${data.slug}`">
-      <div role="group" class="mx-1 my-1 btn-group btn-group-sm">
-        <a class="btn btn-primary btn-sm rounded-pill tagbutton">
-          {{ data.title }}
-        </a>
+      <div role="group" class="mx-1 mt-1 btn-group btn-group-sm">
+        <button
+          type="button"
+          class="btn btn-primary btn-sm rounded-pill tagbutton"
+          data-toggle="tooltip"
+          data-color="blue"
+          data-placement="bottom"
+          :title="data.title"
+        >
+          <span>{{ data.title }}</span>
+        </button>
       </div>
     </router-link>
-  </div>
-  <div v-else>
-    <div role="group" class="mx-1 my-1 btn-group btn-group-sm">
-      <a
-        class="btn btn-primary btn-sm rounded-pill tagbutton"
-        :href="`./files/${data.slug}`"
-      >
-        {{ data.title }}
-      </a>
-    </div>
   </div>
 </template>
 
@@ -36,6 +50,10 @@ defineProps({
   font-weight: 600;
   font-size: 0.775rem;
   border: 0;
+  max-width: calc(min(100vw/2.5, 180px));
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 .tagbutton:hover {
   background-color: black !important;

--- a/zimui/src/components/TagButton.vue
+++ b/zimui/src/components/TagButton.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+defineProps({
+  data: {
+    type: Object,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <router-link class="text-decoration-none text-reset" :to="`./${data.slug}`">
+    <div role="group" class="mx-1 my-1 btn-group btn-group-sm">
+      <a class="btn btn-primary btn-sm rounded-pill tagbutton" style="">
+        {{ data.title }}
+      </a>
+    </div>
+  </router-link>
+</template>
+
+<style scoped>
+.tagbutton {
+  padding: 0.375rem 0.75rem;
+  background-color: black;
+  font-weight: 600;
+  font-size: 0.775rem;
+  border: 0;
+}
+.tagbutton:hover {
+  background-color: black !important;
+  opacity: 80% !important;
+}
+</style>

--- a/zimui/src/components/ToolBar.vue
+++ b/zimui/src/components/ToolBar.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import Topic from '@/types/Topic'
+import { PropType } from 'vue'
+import TagButton from '../components/TagButton.vue'
+
+defineProps({
+  topic: {
+    type: Object as PropType<Topic>,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <div class="mt-2 container btn-toolbar" role="toolbar">
+    <TagButton
+      v-for="content in topic.sections"
+      :key="content.slug"
+      :data="content"
+    />
+  </div>
+</template>
+
+<style scoped></style>

--- a/zimui/src/components/ToolBar.vue
+++ b/zimui/src/components/ToolBar.vue
@@ -1,23 +1,112 @@
 <script setup lang="ts">
-import Topic from '@/types/Topic'
-import { PropType } from 'vue'
+import TopicSectionType from '@/types/TopicSection'
+import { PropType, onMounted, ref, watch } from 'vue'
 import TagButton from '../components/TagButton.vue'
 
-defineProps({
-  topic: {
-    type: Object as PropType<Topic>,
+const props = defineProps({
+  sections: {
+    type: Object as PropType<TopicSectionType[]>,
     required: true,
   },
+})
+
+const tags = ref<
+  {
+    title: string
+    slug: string
+  }[]
+>()
+
+const showMore = ref(false)
+
+/**
+ * Limit number of tags based on max number of characters toolbar container can accomodate
+ * maxCharacters = toolbar container width / 7 :150 (dividing factor should be adjusted based on font-size)
+ * Magic 150: With tag button max width (180px) and font size (0.775rem),
+ * we fit max 25-27 characters per tag.
+ * Thus, 150 characters allow for 6-7 tags if container width isn't accessible.
+ * Magic 25: We display a maximum of ~25 characters per tag.
+ * To maximize tag count, we deduct only 25 characters from charLeft,
+ * as we typically utilize no more than 25 characters' worth of space.
+ * @returns number of tags to display
+ */
+const lengthOfTags = function () {
+  const containerWidth = document.querySelector('.container')?.clientWidth
+  const totalCharacters = props.sections.reduce(
+    (acc, content) => acc + content.title.length,
+    0,
+  )
+  const maxCharacters = containerWidth ? containerWidth / 7 : 150
+
+  let tagsToDisplay = props.sections.length
+  if (totalCharacters > maxCharacters) {
+    let charLeft = maxCharacters
+    for (let i = 0; i < props.sections.length; i++) {
+      charLeft -= Math.min(props.sections[i].title.length, 25)
+      if (charLeft < 0) {
+        tagsToDisplay = i + 1
+        break
+      }
+    }
+  }
+  return tagsToDisplay
+}
+
+/** Retrieve limited number of tags */
+const getMaxTags = function () {
+  tags.value = props.sections.slice(0, lengthOfTags()).map((content) => {
+    return {
+      title: content.title,
+      slug: content.slug,
+    }
+  })
+}
+
+/** Retrieve all or less tags*/
+const showMoreOrLess = function () {
+  showMore.value
+    ? getMaxTags()
+    : (tags.value = props.sections.map((content) => {
+        return {
+          title: content.title,
+          slug: content.slug,
+        }
+      }))
+  showMore.value = !showMore.value
+}
+
+watch(props, () => {
+  showMore.value = false
+  getMaxTags()
+})
+
+onMounted(() => {
+  getMaxTags()
+  window.addEventListener('resize', () => {
+    showMore.value = false
+    getMaxTags()
+  })
 })
 </script>
 
 <template>
-  <div class="mt-2 container btn-toolbar" role="toolbar">
-    <TagButton
-      v-for="content in topic.sections"
-      :key="content.slug"
-      :data="content"
-    />
+  <div
+    style="align-items: baseline"
+    class="mt-2 container btn-toolbar toolbar"
+    role="toolbar"
+  >
+    <TagButton v-for="content in tags" :key="content.slug" :data="content" />
+    <div v-if="lengthOfTags() < sections.length">
+      <button
+        style="font-size: 0.7rem"
+        class="btn mt-1 mx-1 py-0 btn-primary btn-sm rounded-pill tagbutton"
+        @click="showMoreOrLess"
+      >
+        <span>
+          {{ showMore ? 'Show less...' : 'Show more...' }}
+        </span>
+      </button>
+    </div>
   </div>
 </template>
 

--- a/zimui/src/components/TopicHome.vue
+++ b/zimui/src/components/TopicHome.vue
@@ -6,6 +6,7 @@ import Topic from '@/types/Topic'
 import { useMainStore } from '../stores/main'
 import TopicSectionType from '@/types/TopicSection'
 import { transformTopicSectionOrSubSectionToCardData } from '@/types/TopicCardData'
+import ToolBar from '../components/ToolBar.vue'
 
 const main = useMainStore()
 
@@ -156,6 +157,7 @@ const goToPreviousPage = () => {
       </div>
     </div>
     <div v-if="dataLoaded">
+      <ToolBar :topic="topic" />
       <TopicSection
         v-for="(content, contentIndex) in getTopicSections(topic.sections)"
         :key="contentIndex"

--- a/zimui/src/components/TopicHome.vue
+++ b/zimui/src/components/TopicHome.vue
@@ -157,7 +157,10 @@ const goToPreviousPage = () => {
       </div>
     </div>
     <div v-if="dataLoaded">
-      <ToolBar :topic="topic" />
+      <ToolBar
+        v-if="topic.parents.length == 0"
+        :sections="getTopicSections(topic.sections)"
+      />
       <TopicSection
         v-for="(content, contentIndex) in getTopicSections(topic.sections)"
         :key="contentIndex"

--- a/zimui/src/components/TopicHome.vue
+++ b/zimui/src/components/TopicHome.vue
@@ -158,7 +158,7 @@ const goToPreviousPage = () => {
     </div>
     <div v-if="dataLoaded">
       <ToolBar
-        v-if="topic.parents.length == 0"
+        v-if="getTopicSections(topic.sections).length > 0"
         :sections="getTopicSections(topic.sections)"
       />
       <TopicSection

--- a/zimui/src/style.css
+++ b/zimui/src/style.css
@@ -10,3 +10,10 @@
   margin-right: auto;
   margin-left: auto;
 }
+.tooltip {
+  opacity: 1;
+}
+.tooltip .tooltip-inner {
+  background-color: white;
+  color: black;
+}

--- a/zimui/yarn.lock
+++ b/zimui/yarn.lock
@@ -371,7 +371,7 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@popperjs/core@^2.11.8":
+"@popperjs/core@^2.11.8", "@popperjs/core@^2.9.2":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
@@ -395,6 +395,13 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
+"@types/bootstrap@^5.2.10":
+  version "5.2.10"
+  resolved "https://registry.yarnpkg.com/@types/bootstrap/-/bootstrap-5.2.10.tgz#58506463bccc6602bc051487ad8d3a6458f94c6c"
+  integrity sha512-F2X+cd6551tep0MvVZ6nM8v7XgGN/twpdNDjqS1TUM7YFNEtQYWk+dKAnH+T1gr6QgCoGMPl487xw/9hXooa2g==
+  dependencies:
+    "@popperjs/core" "^2.9.2"
 
 "@types/chai-subset@^1.3.3":
   version "1.3.3"


### PR DESCRIPTION
Adds a toolbar of topics as tags. Solves Issue #60 
1. `TagButton` component - Button with a bootstrap tooltip.
2. `ToolBar` component - 

- Takes list of topics as property and limits the number of topics/tags to be displayed based on a calculation given below.
`maxCharacters = containerWidth ? containerWidth / 7 : 150` (7 - this factor was chosen based on multiple experiments and depends on button text font size)
    If total Characters in list of topics is greater than maxCharacters than we will limit the number of topics to be displayed based on the following calculation
`let charLeft = maxCharacters`
   ` for (let i = 0; i < props.topics.length; i++) {`
     ` charLeft -= Math.min(props.topics[i].title.length, 25)`
      `if (charLeft < 0) {`
        `topicsToDisplay = i + 1`
        `break}}`
`Math.min(props.topics[i].title.length, 25)` - Here, 25 is used so that a very big title ( say 80 characters) won't be considered as a title of length 80 characters as around 25-27 characters will only get displayed ( for tag button - `max-width: calc(min(100vw/2.5, 180px)); text-overflow: ellipsis;`), hence it helps to include more topics in toolbar

- showmore/less button: visible if when lengthOfTags < topics.length

3. Feature Demo:

https://github.com/openzim/kolibri/assets/96630446/450be5e3-0485-4400-be4e-de7460191fee

- [x] TagBar
- [x] TagButton Tooltip
- [x] Show more / Show less button
- [x] Toolbar should take 2- 4 rows maximum

Additional - There could be a better way for choosing how many tags to display.
