### PR TITLE
png module not found fix

### DIFF
--- a/zimui/src/vue-shims.d.ts
+++ b/zimui/src/vue-shims.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+  const value: string;
+  export default value;
+}


### PR DESCRIPTION
`closes` #124 

![Screenshot from 2024-04-04 14-22-36](https://github.com/openzim/kolibri/assets/137636943/1732ca37-1a55-406e-924b-dd7e11a64487)

Now the image files are getting recognized as modules and the error previously encountered is resolved.