### PR TITLE
Fixed Issue #132

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Development
 
 kolibri2zim adheres to openZIM's [Contribution Guidelines](https://github.com/openzim/overview/wiki/Contributing).
 
-kolibri2zim has implemented openZIM's [Python bootstrap, conventions and policies](https://github.com/openzim/_python-bootstrap/docs/Policy.md) **v1.0.0**.
+kolibri2zim has implemented openZIM's [Python bootstrap, conventions and policies](https://github.com/openzim/_python-bootstrap/blob/main/docs/Policy.md) **v1.0.0**.
 
 Before contributing be sure to check out the
 [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.


### PR DESCRIPTION
## Fix Broken Link in README.md

**Issue Reference:** #132

### Description

This PR addresses a broken link in the `README.md` file. The link anchored "Python bootstrap, conventions and policies" was previously pointing to a non-existent page, resulting in a 'Not Found' error. This has been updated to direct users to the correct resource.

### Changes Made

- Updated the URL for "Python bootstrap, conventions and policies" in `README.md` to: [https://github.com/openzim/_python-bootstrap/blob/main/docs/Policy.md](https://github.com/openzim/_python-bootstrap/blob/main/docs/Policy.md)

### Screenshots

**Before:**

<img width="496" alt="kolibri READ me 404 link page" src="https://github.com/user-attachments/assets/3dbdf4ad-e030-4740-b4d5-5360ff17a12b" />


**After:**

![Fixed Link Screenshot](https://github.com/user-attachments/assets/7f743f86-d910-4e36-aaed-7b33be221f4c)

### Testing

- Verified that the updated link in `README.md` navigates to the correct page without errors.

### Additional Notes

Ensuring that documentation links are accurate is crucial for user guidance and project credibility. This fix enhances the usability of our documentation.

---

*Please let me know if further adjustments are required.*
