### PR TITLE
Added language customization via CLI parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated the error display to a modern UI. (#131)
 
+### Added
+- Language metadata can be customized via `--lang` CLI parameter (#41).
+
+### Changed
+- Default language is now sourced from channel metadata if available, otherwise falls back to `eng`.
+- Added validation for ISO 639-3 language codes.
+
 ## [1.2.1] - 2024-02-29
 
 ### Changed

--- a/scraper/dump_channel_to_fs.py
+++ b/scraper/dump_channel_to_fs.py
@@ -2,20 +2,20 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 
-""" dump a channel content into a folder
+"""dump a channel content into a folder
 
-    Using a channel_id, download all files it is consisted of and store them in a local
-    folder mimicing the studio URLs.
+Using a channel_id, download all files it is consisted of and store them in a local
+folder mimicing the studio URLs.
 
-    This allows running kolibri2zim off a local *mirror* of the actual Kolibri Studio
-    this saving a lot of bandwidth/time during dev and saving those resources
-    on kolibri side as well.
+This allows running kolibri2zim off a local *mirror* of the actual Kolibri Studio
+this saving a lot of bandwidth/time during dev and saving those resources
+on kolibri side as well.
 
-    Just serve build folder via webserver and change STUDIO_URL env for kolibri2zim
-    caddy file-server -browse -listen 0.0.0.0:8888 -root build
-    STUDIO_URL=http://localhost:8888 kolibri2zim --channel_id xxx
+Just serve build folder via webserver and change STUDIO_URL env for kolibri2zim
+caddy file-server -browse -listen 0.0.0.0:8888 -root build
+STUDIO_URL=http://localhost:8888 kolibri2zim --channel_id xxx
 
-    Uses wget for downloads """
+Uses wget for downloads"""
 
 import contextlib
 import logging

--- a/scraper/src/kolibri2zim/entrypoint.py
+++ b/scraper/src/kolibri2zim/entrypoint.py
@@ -39,11 +39,12 @@ def parse_args(raw_args):
         required=True,
     )
 
+    # Change from default "eng" to None and adjust help text
     parser.add_argument(
         "--lang",
-        help="ZIM Language, used in metadata (should be a ISO-639-3 language code). "
-        "If unspecified, scraper will use 'eng'",
-        default="eng",
+        help="ISO 639-3 code to override the channel's language metadata in ZIM. "
+             "Uses channel language if not provided.",
+        default=None,  # Remove hardcoded default
     )
 
     parser.add_argument(

--- a/scraper/src/kolibri2zim/entrypoint.py
+++ b/scraper/src/kolibri2zim/entrypoint.py
@@ -42,8 +42,8 @@ def parse_args(raw_args):
     parser.add_argument(
         "--lang",
         help="ISO 639-3 code to override the channel's language metadata in ZIM. "
-             "Uses channel language if not provided.",
-        default=None,  
+        "Uses channel language if not provided.",
+        default=None,
     )
 
     parser.add_argument(

--- a/scraper/src/kolibri2zim/entrypoint.py
+++ b/scraper/src/kolibri2zim/entrypoint.py
@@ -39,12 +39,11 @@ def parse_args(raw_args):
         required=True,
     )
 
-    # Change from default "eng" to None and adjust help text
     parser.add_argument(
         "--lang",
         help="ISO 639-3 code to override the channel's language metadata in ZIM. "
              "Uses channel language if not provided.",
-        default=None,  # Remove hardcoded default
+        default=None,  
     )
 
     parser.add_argument(

--- a/scraper/src/kolibri2zim/scraper.py
+++ b/scraper/src/kolibri2zim/scraper.py
@@ -1086,10 +1086,12 @@ class Kolibri2Zim:
 
     def sanitize_inputs(self):
         channel_meta = self.db.get_channel_metadata(self.channel_id)
-
-        # Set language from channel metadata if not provided via CLI
-        if not self.language:
-            self.language = channel_meta.get("language", "eng")
+        
+        self.language = self.language or channel_meta.get("language") or "eng"
+        
+        if len(self.language) != 3:
+            logger.warning(f"Ignoring invalid language code: {self.language}")
+            self.language = "eng"
 
         # input  & metadata sanitation
         period = datetime.date.today().strftime("%Y-%m")

--- a/scraper/src/kolibri2zim/scraper.py
+++ b/scraper/src/kolibri2zim/scraper.py
@@ -1086,9 +1086,9 @@ class Kolibri2Zim:
 
     def sanitize_inputs(self):
         channel_meta = self.db.get_channel_metadata(self.channel_id)
-        
+
         self.language = self.language or channel_meta.get("language") or "eng"
-        
+
         if len(self.language) != 3:
             logger.warning(f"Ignoring invalid language code: {self.language}")
             self.language = "eng"

--- a/scraper/src/kolibri2zim/scraper.py
+++ b/scraper/src/kolibri2zim/scraper.py
@@ -1087,6 +1087,10 @@ class Kolibri2Zim:
     def sanitize_inputs(self):
         channel_meta = self.db.get_channel_metadata(self.channel_id)
 
+        # Set language from channel metadata if not provided via CLI
+        if not self.language:
+            self.language = channel_meta.get("language", "eng")
+
         # input  & metadata sanitation
         period = datetime.date.today().strftime("%Y-%m")
         if self.fname:

--- a/scraper/tests/conftest.py
+++ b/scraper/tests/conftest.py
@@ -25,8 +25,9 @@ class FakeDb(KolibriDB):
             "name": self.channel_name,
             "description": self.channel_description,
             "author": self.channel_author,
-            "language": self.channel_language,  
+            "language": self.channel_language,
         }
+
 
 @pytest.fixture()
 def channel_name() -> Generator[str, None, None]:

--- a/scraper/tests/conftest.py
+++ b/scraper/tests/conftest.py
@@ -13,18 +13,20 @@ class FakeDb(KolibriDB):
         channel_name: str,
         channel_description: str,
         channel_author: str | None,
+        channel_language: str = "eng",  # Added parameter with default value
     ):
         self.channel_name = channel_name
         self.channel_description = channel_description
         self.channel_author = channel_author
+        self.channel_language = channel_language  # Store the language
 
     def get_channel_metadata(self, channel_id):  # noqa: ARG002
         return {
             "name": self.channel_name,
             "description": self.channel_description,
             "author": self.channel_author,
+            "language": self.channel_language,  
         }
-
 
 @pytest.fixture()
 def channel_name() -> Generator[str, None, None]:

--- a/scraper/tests/test_sanitize_inputs.py
+++ b/scraper/tests/test_sanitize_inputs.py
@@ -223,23 +223,36 @@ def test_defaults_args(channel_name, channel_description, channel_author, zim_na
     assert set(scraper.tags) == {"_category:other", "kolibri", "_videos:yes"}
     assert len(scraper.tags) == 3
 
-def test_language_cli_override(channel_name, channel_description, channel_author, zim_name):
+
+def test_language_cli_override(
+    channel_name, channel_description, channel_author, zim_name
+):
     args = parse_args(["--name", zim_name, "--lang", "fra"])
     scraper = Kolibri2Zim(**dict(args._get_kwargs()))
-    scraper.db = FakeDb(channel_name, channel_description, channel_author, channel_language="eng")
+    scraper.db = FakeDb(
+        channel_name, channel_description, channel_author, channel_language="eng"
+    )
     scraper.sanitize_inputs()
     assert scraper.language == "fra"
 
-def test_language_from_channel(channel_name, channel_description, channel_author, zim_name):
+
+def test_language_from_channel(
+    channel_name, channel_description, channel_author, zim_name
+):
     args = parse_args(["--name", zim_name])
     scraper = Kolibri2Zim(**dict(args._get_kwargs()))
-    scraper.db = FakeDb(channel_name, channel_description, channel_author, channel_language="fra")
+    scraper.db = FakeDb(
+        channel_name, channel_description, channel_author, channel_language="fra"
+    )
     scraper.sanitize_inputs()
     assert scraper.language == "fra"
+
 
 def test_language_fallback(channel_name, channel_description, channel_author, zim_name):
     args = parse_args(["--name", zim_name])
     scraper = Kolibri2Zim(**dict(args._get_kwargs()))
-    scraper.db = FakeDb(channel_name, channel_description, channel_author, channel_language=None)
+    scraper.db = FakeDb(
+        channel_name, channel_description, channel_author, channel_language=None
+    )
     scraper.sanitize_inputs()
     assert scraper.language == "eng"

--- a/scraper/tests/test_sanitize_inputs.py
+++ b/scraper/tests/test_sanitize_inputs.py
@@ -222,3 +222,28 @@ def test_defaults_args(channel_name, channel_description, channel_author, zim_na
     # We compare sets because ordering does not matter
     assert set(scraper.tags) == {"_category:other", "kolibri", "_videos:yes"}
     assert len(scraper.tags) == 3
+
+def test_language_handling(channel_name, channel_description, channel_author, zim_name):
+    # Test case 1: CLI language overrides channel language
+    args = parse_args(["--name", zim_name, "--lang", "fra"])
+    scraper = Kolibri2Zim(**dict(args._get_kwargs()))
+    scraper.db = FakeDb(
+        channel_name=channel_name,
+        channel_description=channel_description,
+        channel_author=channel_author,
+        channel_language="eng",  # Channel language is "eng"
+    )
+    scraper.sanitize_inputs()
+    assert scraper.language == "fra"  # CLI language should override
+
+    # Test case 2: No CLI language, use channel language
+    args = parse_args(["--name", zim_name])
+    scraper = Kolibri2Zim(**dict(args._get_kwargs()))
+    scraper.db = FakeDb(
+        channel_name=channel_name,
+        channel_description=channel_description,
+        channel_author=channel_author,
+        channel_language="fra",  # Channel language is "fra"
+    )
+    scraper.sanitize_inputs()
+    assert scraper.language == "fra"  # When not provided by CLI, use channel language

--- a/scraper/tests/test_sanitize_inputs.py
+++ b/scraper/tests/test_sanitize_inputs.py
@@ -223,27 +223,23 @@ def test_defaults_args(channel_name, channel_description, channel_author, zim_na
     assert set(scraper.tags) == {"_category:other", "kolibri", "_videos:yes"}
     assert len(scraper.tags) == 3
 
-def test_language_handling(channel_name, channel_description, channel_author, zim_name):
-    # Test case 1: CLI language overrides channel language
+def test_language_cli_override(channel_name, channel_description, channel_author, zim_name):
     args = parse_args(["--name", zim_name, "--lang", "fra"])
     scraper = Kolibri2Zim(**dict(args._get_kwargs()))
-    scraper.db = FakeDb(
-        channel_name=channel_name,
-        channel_description=channel_description,
-        channel_author=channel_author,
-        channel_language="eng",  # Channel language is "eng"
-    )
+    scraper.db = FakeDb(channel_name, channel_description, channel_author, channel_language="eng")
     scraper.sanitize_inputs()
-    assert scraper.language == "fra"  # CLI language should override
+    assert scraper.language == "fra"
 
-    # Test case 2: No CLI language, use channel language
+def test_language_from_channel(channel_name, channel_description, channel_author, zim_name):
     args = parse_args(["--name", zim_name])
     scraper = Kolibri2Zim(**dict(args._get_kwargs()))
-    scraper.db = FakeDb(
-        channel_name=channel_name,
-        channel_description=channel_description,
-        channel_author=channel_author,
-        channel_language="fra",  # Channel language is "fra"
-    )
+    scraper.db = FakeDb(channel_name, channel_description, channel_author, channel_language="fra")
     scraper.sanitize_inputs()
-    assert scraper.language == "fra"  # When not provided by CLI, use channel language
+    assert scraper.language == "fra"
+
+def test_language_fallback(channel_name, channel_description, channel_author, zim_name):
+    args = parse_args(["--name", zim_name])
+    scraper = Kolibri2Zim(**dict(args._get_kwargs()))
+    scraper.db = FakeDb(channel_name, channel_description, channel_author, channel_language=None)
+    scraper.sanitize_inputs()
+    assert scraper.language == "eng"


### PR DESCRIPTION
Closes #41 and #126 

- Added language customization via the --lang CLI parameter to override ZIM language metadata.

**Changes** ->
- Modified --lang parameter in entrypoint.py to default to None instead of "eng"
- Updated sanitize_inputs() in scraper.py to:
  - Use CLI language when provided
  - Fall back to channel language when not provided
  - Default to "eng" if neither is available
- Added tests in test_sanitize_inputs.py to verify both override and fallback behavior

##All tests pass, including new test cases for this feature.