### PR TITLE
Align Vue.js configuration with latest changes

### DIFF
--- a/zimui/.eslintrc.cjs
+++ b/zimui/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
     'eslint:recommended',
     'plugin:vue/vue3-recommended',
     '@vue/eslint-config-typescript/recommended',
-    'prettier',
+    '@vue/eslint-config-prettier/skip-formatting',
   ],
   rules: {
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],

--- a/zimui/.prettierrc.json
+++ b/zimui/.prettierrc.json
@@ -1,4 +1,8 @@
 {
+  "$schema": "https://json.schemastore.org/prettierrc",
   "semi": false,
-  "singleQuote": true
+  "tabWidth": 2,
+  "singleQuote": true,
+  "printWidth": 100,
+  "trailingComma": "none"
 }


### PR DESCRIPTION
- Updated `.prettierrc` with schema reference, tab width, and other formatting rules.
- Synced `.eslintrc.cjs` by extending `prettier` and `@vue/eslint-config-prettier/skip-formatting`. 
- Related to #130
