### PR TITLE
change type of about flags to html blob

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -70,7 +70,8 @@
       "description": "URL to a single CSS file to be included in all pages (but not on kolibri-html-content ones). Inlude external resources using data URL."
     },
     "about": {
-      "type": "url",
+      "type": "blob",
+      "kind": "html",
       "required": false,
       "title": "Custom About",
       "description": "URL to a single HTML file to use as an about page. Place everythong inside `body .container` (including stylesheets and scripts) as only this and your <title> will be merged into the actual about page. Remember to include images inline using data URL."


### PR DESCRIPTION
## Rationale
See openzim/zimfarm#1574

## Changes
- change `about` flag from url to html blob